### PR TITLE
SSH input

### DIFF
--- a/assets/js/machines/sshkey.js
+++ b/assets/js/machines/sshkey.js
@@ -1,7 +1,9 @@
 $(function() {
     $('#sshform').submit(function() {
         var key = $("#sshkey").val();
-    
+        if (key === "") {
+            key = "\n";
+        }
         $.ajax({
             type: "POST",
             url: "/api/user",


### PR DESCRIPTION
If the textarea is blank, `key` will be set to a newline character - but users will just see an empty textarea. Fixes #24
