### PR TITLE
Restructuring of menus and pages

### DIFF
--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -3,13 +3,13 @@
  * depending on if the session cookie is set.
  */
 $(function() {
-    if ($.cookie('session') == undefined || $.cookie('session') == "") {
-        $("#logintoolbar").show();
-        $("#logouttoolbar").hide();
+    if ($.cookie('session') === undefined || $.cookie('session') === "") {
+        $(".logintoolbar").show();
+        $(".logouttoolbar").hide();
     } else {
         $("#user").html($.cookie('name'));
-        $("#logouttoolbar").show();
-        $("#logintoolbar").hide();
+        $(".logouttoolbar").show();
+        $(".logintoolbar").hide();
     }
 
     $('#logout').click(function() {

--- a/views/home/index.html
+++ b/views/home/index.html
@@ -13,30 +13,28 @@
 
 {% block content %}
 <div class="row">
-{% set submenufocus = "home" %}
-{% include "home/homesubmenu.html" %}
-    <div class="col-md-10">
+    <div class="col-md-12">
+        <div class="jumbotron">
+            <h1 class="page-header">Welcome</h1>
+            <img src="/assets/images/clouds.png" style="float:right;width:300px;padding-left:40px" />
+            <p>
+                Welcome to the SCD Cloud. This service provides a private <abbr title="Infrastucture as a Service">IaaS</abbr> cloud resource for SCD users.
+                To start, select the login link at the top of the page and enter your federal username and password.
+            </p>
+            <p>
+                You should be aware that the SCD Cloud is still in active development. Please read the <a href="/tos">Terms of Service</a> before proceeding.
+            </p>
+            <p>
+                For any questions, problems or ideas email us at <a href="mailto:{{ email }}">{{ email }}</a>
+            </p>
+        </div>
         <div id="carousel" class="carousel slide" data-ride="carousel">
             <div class="carousel-inner" role="listbox">
                 <div class="item active">
-                    <h1 class="page-header">Welcome</h1>
-                    <img src="/assets/images/clouds.png" style="float:right;width:300px;padding-left:40px" />
-                    <p>
-                        Welcome to the SCD Cloud. This service provides a private <abbr title="Infrastucture as a Service">IaaS</abbr> cloud resource for SCD users.
-                        To start, select the login link at the top of the page and enter your federal username and password.
-                    </p>
-                    <p>
-                        You should be aware that the SCD Cloud is still in active development. Please read the <a href="/tos">Terms of Service</a> before proceeding.
-                    </p>
-                    <p>
-                        For any questions, problems or ideas email us at <a href="mailto:{{ email }}">{{ email }}</a>
-                    </p>
-                </div>
-                <div class="item">
                     <h1 class="page-header">Infrastructure</h1>
                     <img src="/assets/images/rack.png" style="width:170px;float:right;margin-top:-15px" />
                     <p>
-                        The cloud is based on <a href="http://opennebula.org">OpenNebula</a> for the virtualisation and <a href="http://ceph.com">CEPH</a> for the storage. For the hardware, we use 
+                        The cloud is based on <a href="http://opennebula.org">OpenNebula</a> for the virtualisation and <a href="http://ceph.com">CEPH</a> for the storage. For the hardware, we use
                         <ul>
                             <li>28x Dell R420 for the hypervisors</li>
                             <li>30x Dell R520 for the storage nodes</li>
@@ -66,7 +64,6 @@
             <ol class="carousel-indicators">
                 <li data-target="#carousel" data-slide-to="0" class="active"></li>
                 <li data-target="#carousel" data-slide-to="1"></li>
-                <li data-target="#carousel" data-slide-to="2"></li>
             </ol>
         </div>
     </div>

--- a/views/home/tos.html
+++ b/views/home/tos.html
@@ -3,11 +3,8 @@
 {% extends "layout.html" %}
 
 {% block content %}
-
 <div class="row">
-{% set submenufocus = "tos" %}
-{% include "home/homesubmenu.html" %}
-    <div class="col-md-10">
+    <div class="col-md-12">
         <h1 class="page-header">Terms of Service</h1>
         <p>
             This is a service under continual development. If you are unsure about ANY of the following conditions of use or how they apply to you or your intended use of this service then, BEFORE continuing, please contact the Cloud Service Managers at <a href="mailto:{{ email }}">{{ email }}</a> who will be pleased to help.
@@ -15,14 +12,23 @@
             By continuing to log in you agree to abide by the following conditions of use of this service ?
             <ol>
                 <li>You MUST comply with Organisational Information Security Policy particularly regarding the Roles and Responsibilities of System Administrators together with familiarising yourself with the supporting policy framework available at <a href="https://staff.stfc.ac.uk/core/security/information/Pages/default.aspx">https://staff.stfc.ac.uk/core/security/information/Pages/default.aspx</a></li>
+                <br />
                 <li>You MUST NOT, except by WRITTEN authorization from the Cloud Service Managers, disable or otherwise modify or degrade the configuration of installed system monitoring and management tools including but not limited to that of rsyslog, pakiti, ssh, yum and auto-updating</li>
+                <br />
                 <li>You UNDERSTAND that, whilst best effort is made to provide a stable platform, VMs may be subject to interruption and/or data loss at any time without notice (this is a development platform and should not be used for production services)</li>
+                <br />
                 <li>With respect to any SOFTWARE that you install you MUST ensure that all applicable license and terms and conditions of use are met </li>
+                <br />
                 <li>You MUST NOT use the service in any way related to providing any commercial service or running a private business</li>
+                <br />
                 <li>You MUST report any suspected or actual security incident or other misuse of the VM immediately to <a href="mailto:{{ email }}">{{ email }}</a> and notify the appropriate STFC security contact by following the procedure at <a href="https://staff.stfc.ac.uk/core/security/information/Pages/Incidents.aspx">https://staff.stfc.ac.uk/core/security/information/Pages/Incidents.aspx</a></li>
+                <br />
                 <li>Credentials applicable to the VM (such as X509 host certificate and Kerberos private keys) MUST be obtained through the Cloud Service Managers. You MUST apply and maintain appropriate protection to prevent exposure or misuse for all such credentials and NOT export private keys or take any other action which would prejudice credential re-use in future VM instances.</li>
+                <br />
                 <li>You will be informed by email of any changes to these conditions and MUST inform the Cloud Service Managers immediately if you can no longer abide by the updated conditions. The latest conditions of these conditions are available at <a href="https://cloud.stfc.ac.uk/tos">https://cloud.stfc.ac.uk/tos</a></li>
+                <br />
                 <li>You AGREE that you can be held liable for any consequences of your failure to abide by these conditions of use including, but not limited to, the possible immediate termination of your VM without notice, reporting to your organisational management and, if thought to be appropriate, necessary law enforcement agencies.</li>
+                <br />
             </ol>
         </p>
     </div>

--- a/views/layout.html
+++ b/views/layout.html
@@ -29,20 +29,24 @@
 
                         <div id="navbar" class="navbar-collapse collapse">
                             <ul class="nav navbar-nav">
-                                <li{{ ' class="active"' if menufocus == 'machines' }}><a href="/machines">Machines</a></li>
+                                <li{{ ' class="active"' if title == 'Home' }}><a href="/">Home</a></li>
+                                <li{{ ' class="active"' if title == 'Terms of Service' }}><a href="/tos">Terms</a></li>
                             </ul>
                             <ul class="nav navbar-nav navbar-right">
-                                <li id="logouttoolbar" class="dropdown" style="display:none">
+                                <li class="logouttoolbar {{ 'active' if title == 'Machines' }}"><a href="/machines">My Machines</a></li>
+                                <li class="logouttoolbar {{ 'active' if title == 'Machine FAQ' }}"><a href="/machines/faq">FAQs</a></li>
+                                <li class="logouttoolbar" class="dropdown" style="display:none">
                                     <a href="#" data-toggle="dropdown" class="dropdown-toggle">
                                         <span class="glyphicon glyphicon-user"></span>
                                         <span id="user" style="padding:0 15px"></span>
                                         <b class="caret"></b>
                                     </a>
                                     <ul class="dropdown-menu" style="min-width:0px !important;width:100%">
+                                        <li><a href="/machines/ssh">SSH Key</a></li>
                                         <li><a href="#" id="logout" style="">Logout</a></li>
                                     </ul>
                                 </li>
-                                <li id="logintoolbar" style="display:none">
+                                <li class="logintoolbar" style="display:none">
                                     <a href="/login">
                                         <span class="glyphicon glyphicon-log-in"></span>
                                         <span style="padding:0 15px">Login</span>

--- a/views/machines/faq.html
+++ b/views/machines/faq.html
@@ -1,4 +1,3 @@
-{% set menufocus = "machines" %}
 {% set title = "Machine FAQ" %}
 
 {% extends "layout.html" %}
@@ -84,7 +83,7 @@
         <br />
         <h3><a name="pakiti" href="#pakiti" class="faq">9. Why are Pakiti and rsyslog running on my VM?</a></h3>
         <p>
-            These services are used for monitoring and security. Please refrain from stopping or changing the behaviour of either of these service. Please make sure you have read the <a href="/tos">Terms of Service</a>. 
+            These services are used for monitoring and security. Please refrain from stopping or changing the behaviour of either of these service. Please make sure you have read the <a href="/tos">Terms of Service</a>.
         </p>
     </div>
 </div>


### PR DESCRIPTION
- Front page now uses a Bootstrap Jumbotron.
- Front page no longer uses side menu.
-  'Terms of Service' is now linked on the main menu.
- The 'Machines' page renamed to 'My Machines' and will now only show when user is logged in.
- The machine 'FAQs' page is now linked on the main menu - only shows when the user is logged in.
- Resolves #1 and #19 
