### PR TITLE
History page update to use new way of displaying vm states

### DIFF
--- a/assets/js/machines/history.js
+++ b/assets/js/machines/history.js
@@ -6,14 +6,12 @@ var offset = 0;
 var numvms = 0;
 var pagesize = 5;
 
-var VM_STATES = ["INIT", "PENDING", "HOLD", "ACTIVE", "STOPPED", "SUSPENDED", "DONE", "FAILED", "POWER OFF", "STOPPING"]
-var STATE_STYLE = ["primary", "primary", "info", "success", "warning", "warning", "default", "danger", "warning", "warning"]
 var MONTHS = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
 
 function formatDate(timestamp)
 {
-    if (timestamp == 0) {
-        return "-"
+    if (timestamp === 0) {
+        return "-";
     }
 
     var date = new Date(timestamp*1000);
@@ -24,7 +22,7 @@ function formatDate(timestamp)
     datestring += ("0" + date.getUTCHours()).slice (-2) + ":";
     datestring += ("0" + date.getUTCMinutes()).slice (-2) + ":";
     datestring += ("0" + date.getUTCSeconds()).slice (-2);
-    return datestring
+    return datestring;
 }
 
 function createVMlist()
@@ -46,11 +44,33 @@ function createVMlist()
         }
     }).done(function(json) {
         var html = "";
+
         $.each(json, function(index, vm) {
+            state = vm['state'];
+            disabled = (state != "RUNNING" ? "disabled" : "");
+
+            if (state === "POWERED OFF") {
+                state_val = 0;
+            }
+            else if (state ===  "PENDING" || state === "DELETING") {
+                state_val = 1;
+            }
+            else if (state ===  "TRANSFER") {
+                state_val = 2;
+            }
+            else if (state ===  "BUILDING" || state === "EPILOG") {
+                state_val = 3;
+            }
+            else if (state ===  "RUNNING") {
+                state_val = 4;
+            }
+            else {
+                state_val = 0;
+            }
             html += '<tr>';
             html += '<td>' + vm['name'] + '</td>';
             html += '<td>' + vm['hostname'] + '</td>';
-            html += '<td><span class="label label-' + STATE_STYLE[vm['state']] + '" style="display:inline-block;width:100%">' + VM_STATES[vm['state']] + '</span></td>';
+            html += '<td><progress max="4" value="'+state_val+'"></progress><span class="status-label">'+state+'</span></td>';
             html += '<td>' + vm['type'] + '</td>';
             html += '<td>' + formatDate(vm['stime']) + '</td>';
             html += '<td>' + formatDate(vm['etime']) + '</td>';
@@ -58,7 +78,10 @@ function createVMlist()
             html += '<td>' + (vm['memory']/1024) + "GB" + '</td>';
             html += '</tr>';
         });
-        $("#vms").empty();
-        $("#vms").append(html);
+        if (html !== "") {
+            $("#vms").empty();
+            $("#vms").append(html);
+        }
+        $("#error").hide();
     });
 }

--- a/controllers/api/vm.py
+++ b/controllers/api/vm.py
@@ -172,6 +172,8 @@ class VM(object):
                     state = "RUNNING"
             elif vm.find('STATE').text in ["4","5","8"]:
                 state = "POWERED OFF"
+            else:
+                state = "DONE"
             if vm.find('TEMPLATE').find('VCPU') != None:
                 cpu = vm.find('TEMPLATE').find('VCPU').text
             else:


### PR DESCRIPTION
The History page wasn't updated to use the new way of handling the way we display VM states.
- Adds the `Done` state.
- Status is now shown using a progress bar
- Added missing semicolons 
