### PR TITLE
Tickbox to select VM list to be user or group

### DIFF
--- a/assets/js/machines/listmachines.js
+++ b/assets/js/machines/listmachines.js
@@ -1,5 +1,8 @@
 /*jshint sub:true*/
 var MONTHS = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+if ($.cookie("showall") == "true") {
+    $('#show-all').prop('checked', true);
+}
 
 function formatDate(timestamp)
 {
@@ -16,6 +19,8 @@ function formatDate(timestamp)
 
 function drawTable()
 {
+    var show = $('#show-all').prop('checked');
+    $.cookie("showall", show, {path : '/'});
     $.ajax({
         type: "GET",
         url: "/api/vm?size=" + pagesize + "&offset=" + offset,

--- a/controllers/api/vm.py
+++ b/controllers/api/vm.py
@@ -113,12 +113,17 @@ class VM(object):
         HEADNODE = cherrypy.request.config.get("headnode")
         FEDID = cherrypy.request.cookie.get('fedid').value
         SESSION = cherrypy.request.cookie.get('session').value
+        SHOWALL = cherrypy.request.cookie.get('showall').value
+        if SHOWALL == "true":
+            show_vms = -2
+        else :
+            show_vms = -3
 
         server = xmlrpclib.ServerProxy(HEADNODE)
 
         request = [
             "%s:%s"%(FEDID,SESSION),   # auth token
-            -3,                        # show only user's VMs
+            show_vms,                  # show only user's VMs or group VMs
             int(offset),               # offest for pagination
             -1 * int(size),            # number of entries to return
             -1 if history == 0 else -2 # show either active or all VMs

--- a/views/machines/index.html
+++ b/views/machines/index.html
@@ -19,7 +19,9 @@ $(function() {
     quota.update();
     setInterval(function () {
         quota.update();
-    }, 5000);
+    }, 5000);$('#show-all').change(function() {
+        drawTable();
+    });
 });
 
 </script>
@@ -49,6 +51,9 @@ $(function() {
             <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> <span id="errormessage"></span>
             <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         </div>
+
+        <span>Show Group VMs?</span>
+        <input id="show-all" type="checkbox">
 
         <button type="button" class="btn btn-blue pull-right" onclick="createVMdialog()"><img src="/assets/images/icon-vm.png" style="width:14px;margin-top:-1px;" />&nbsp;&nbsp;Create Machine</button>
 

--- a/views/machines/index.html
+++ b/views/machines/index.html
@@ -19,7 +19,8 @@ $(function() {
     quota.update();
     setInterval(function () {
         quota.update();
-    }, 5000);$('#show-all').change(function() {
+    }, 5000);
+    $('#show-all').change(function() {
         drawTable();
     });
 });


### PR DESCRIPTION
- Added a tickbox at the top right of the machines page.
- Tickbox creates and updates a cookie.
- `controllers/api/vm.py` now reads the cookie to return the relevant list.
- Resolves #55 
