### PR TITLE
Add warning for users who do not have templates available

### DIFF
--- a/assets/js/machines/pickmachinetype.js
+++ b/assets/js/machines/pickmachinetype.js
@@ -31,7 +31,11 @@ function draw_buttons() {
     var os_flavour,release,type,image = null;
     $("#aquilon-select").css("display", "none");
 
-    if (selected_flavour === "") {
+    if ($.isEmptyObject(image_list)) {
+        buttons = '<div class="alert alert-danger" role="alert"><p>You do not appear to have any templates available to you. Please contact <a href="mailto:' + EMAIL + '">' + EMAIL + '</a>.</p></div>';
+        $("#create-btn").attr('onclick', "").css('cursor', 'not-allowed');
+    }
+    else if (selected_flavour === "") {
         selected_release = "";
         selected_type = "";
         selected_template = "";

--- a/views/machines/index.html
+++ b/views/machines/index.html
@@ -13,6 +13,7 @@
 var INCLUDE_URI = "/assets/js/machines/novnc/";
 var WSHOSTNAME = "{{ wshostname }}";
 var WSPORT = "{{ wsport }}";
+var EMAIL = "{{ email }}";
 
 $(function() {
     drawTable();


### PR DESCRIPTION
- Will show a box in the 'Chose a Template' section telling users to contact support if they do not have templates available to them.
- If warning is in place, 'create' button will be unusable.
- Fixes #65 
