### PR TITLE
Fix for noVNC

### DIFF
--- a/assets/js/machines/vnc.js
+++ b/assets/js/machines/vnc.js
@@ -47,7 +47,6 @@ function updateState(rfb, state, oldstate, msg) {
     var s, sb, cad, level;
     s = $D('noVNC_status');
     sb = $D('noVNC_status_bar');
-    cad = $D('sendCtrlAltDelButton');
     switch (state) {
         case 'failed':       level = "error";  break;
         case 'fatal':        level = "error";  break;
@@ -55,13 +54,6 @@ function updateState(rfb, state, oldstate, msg) {
         case 'disconnected': level = "normal"; break;
         case 'loaded':       level = "normal"; break;
         default:             level = "warn";   break;
-    }
-
-    if (state === "normal") {
-        cad.disabled = false;
-    } else {
-        cad.disabled = true;
-        xvpInit(0);
     }
 
     if (typeof(msg) !== 'undefined') {

--- a/controllers/api/vm.py
+++ b/controllers/api/vm.py
@@ -155,7 +155,9 @@ class VM(object):
                 hostname = "-"
 
             # get/generate vnc token
-            token = createToken(FEDID, SESSION, vm.find('ID').text)
+            token = getToken(FEDID, vm.find('ID').text)
+            if token == None:
+                token = createToken(FEDID, SESSION, vm.find('ID').text)
 
             if vm.find('STATE').text == "1":
                 state = "PENDING"

--- a/helpers/vnctokens.py
+++ b/helpers/vnctokens.py
@@ -45,7 +45,7 @@ def createToken(fedid, session, id):
         port = vm.find('TEMPLATE').find('GRAPHICS').find('PORT').text
         line = token + ": " + host + ":" + port
 
-        with open(WSTOCKENDIR + fedid, "a") as file:
+        with open(WSTOCKENDIR + fedid+"_"+str(id), "w") as file:
             file.write(line + "\n")
 
     return token
@@ -55,12 +55,12 @@ def getToken(fedid, id):
 
     WSTOCKENDIR = cherrypy.request.config.get("wstokendir")
 
-    if os.path.exists(WSTOCKENDIR + fedid) == False:
-        file = open(WSTOCKENDIR + fedid, 'w+')
+    if os.path.exists(WSTOCKENDIR + fedid+'_'+str(id)) == False:
+        file = open(WSTOCKENDIR + fedid + '_' + str(id), 'w+')
         file.close()
 
     token = None
-    with open(WSTOCKENDIR + fedid, "r") as input:
+    with open(WSTOCKENDIR + fedid + '_' + str(id), "r") as input:
         for line in input:
             match = regex.match(line)
             if match.group(2) == str(id):

--- a/views/machines/novnc/novnc.html
+++ b/views/machines/novnc/novnc.html
@@ -13,7 +13,6 @@
                     <div id="noVNC_status_bar" class="noVNC_status_bar" style="margin-top: 0px;">
                         <div id="noVNC_status" style="position: relative; height: auto;">Loading</div>
                         <div id="noVNC_buttons">
-                            <input type=button value="Send CtrlAltDel" id="sendCtrlAltDelButton" >
                             <span id="noVNC_xvp_buttons"></span>
                         </div>
                     </div>


### PR DESCRIPTION
More work will need to be done on the token system. However, this fixes the token directory building up files with 100,000 + lines.
- Generates a token file - per user - per vm.
- Removed button for broken `CtrlAltDel` cmd.
