### PR TITLE
Add failed status

### DIFF
--- a/assets/css/machines/styles.css
+++ b/assets/css/machines/styles.css
@@ -110,6 +110,7 @@ progress[value="4"]::-moz-progress-bar {
 .status-label-2 {color: #ef8200;}
 .status-label-3 {color: #efbe00;}
 .status-label-4 {color: #24990b;}
+.status-label-5 {color: #ffffff;background-color: #FF0000;}
 
 
 .pagination > .active > a, .pagination > .active > a:focus, .pagination > .active > a:hover, .pagination > .active > span, .pagination > .active > span:focus, .pagination > .active > span:hover {

--- a/assets/js/machines/history.js
+++ b/assets/js/machines/history.js
@@ -72,6 +72,9 @@ function drawHistory()
             if (state === "POWERED OFF" || state === "DONE") {
                 state_val = 0;
             }
+            else if (state === "FAILED") {
+                state_val = 5;
+            }
             else if (state ===  "PENDING" || state === "DELETING") {
                 state_val = 1;
             }

--- a/assets/js/machines/listmachines.js
+++ b/assets/js/machines/listmachines.js
@@ -73,6 +73,9 @@ function drawTable() {
             if (state === "POWERED OFF") {
                 state_val = 0;
             }
+            else if (state === "FAILED") {
+                state_val = 5;
+            }
             else if (state ===  "PENDING" || state === "DELETING") {
                 state_val = 1;
             }

--- a/assets/js/machines/manage/create/pick-template.js
+++ b/assets/js/machines/manage/create/pick-template.js
@@ -3,6 +3,8 @@ var selected_flavour = '';
 var selected_release = '';
 var selected_type = '';
 var selected_template = '';
+var selected_template_name = '';
+var selected_template_description = '';
 
 $.ajax({
     type: 'GET',
@@ -88,6 +90,7 @@ function draw_buttons() {
     }
 
     else if (selected_type === 'AQ Managed' && selected_template !== '') {
+        $('#pick-resources').show();
         pick_aquilon();
     }
 
@@ -107,10 +110,12 @@ function draw_buttons() {
 
             if (image_list[selected_flavour][selected_release][selected_type].length == 1) {
                 selected_template = image_id;
+                selected_template_name = image_name;
+                selected_template_description = image_description;
                 helptext = '';
                 buttons = 'Complete!<br> You chose ' + image_name + '. ' + image_description;
                 draw_buttons();
-                controls = '<a class="btn btn-danger" id="buttonback" onclick="selected_template=\'\';selected_type=\'\'; draw_buttons(); hide_resources();">Back</a>';
+                controls = '<a class="btn btn-danger" id="buttonback" onclick="selected_template=\'\';selected_type=\'\';selected_template_name=\''+image_name+'\'; selected_template_description=\''+image_description+'\'; draw_buttons();hide_resources();">Back</a>';
             }
             else {
                 helptext = 'Select a template for ' + selected_flavour + ' ' + selected_release + ' ' + selected_type;
@@ -122,8 +127,8 @@ function draw_buttons() {
 
     else {
         $('#pick-resources').show();
-        buttons = 'Complete!<br> You chose ' + image_name + '. ' + image_description;
-        controls = '<a class="btn btn-danger" id="buttonback" onclick="selected_template=\'\'; draw_buttons(); hide_resources();">Back</a>';
+        buttons = 'Complete!<br> You chose ' + selected_template_name + '. ' + image_description;
+        controls = '<a class="btn btn-danger" id="buttonback" onclick="selected_template=\'\'; selected_template_name=\'\'; selected_template_description=\'\'; draw_buttons(); hide_resources();">Back</a>';
     }
     $('#buttonbox').html(buttons);
     $('#helpbox').html(helptext);

--- a/controllers/api/vm.py
+++ b/controllers/api/vm.py
@@ -161,6 +161,8 @@ class VM(object):
 
             if vm.find('STATE').text == "1":
                 state = "PENDING"
+            if vm.find('STATE').text == "7":
+                state = "FAILED"
             elif vm.find('STATE').text == "3":
                 if vm.find('LCM_STATE').text == "1":
                     state = "TRANSFER"
@@ -170,12 +172,15 @@ class VM(object):
                     state = "DELETING"
                 elif vm.find('LCM_STATE').text == "12":
                     state = "EPILOG"
+                elif int(vm.find('LCM_STATE').text) in [ 14 , 19 , 37 , 38 , 39 , 40 , 41 , 42 , 44 , 46 , 47 , 48 , 49 , 50 ]:
+                    state = "FAILED"
                 else:
                     state = "RUNNING"
             elif vm.find('STATE').text in ["4","5","8"]:
                 state = "POWERED OFF"
             else:
                 state = "DONE"
+
             if vm.find('TEMPLATE').find('VCPU') != None:
                 cpu = vm.find('TEMPLATE').find('VCPU').text
             else:


### PR DESCRIPTION
Add a failed status to the Machines and History page to show if there has been a problem with a VM.
This is triggered by either the FAILED state (7) or the following LCM_STATES:

```
FAILURE             = 14,
BOOT_FAILURE            = 36,
BOOT_MIGRATE_FAILURE    = 37,
PROLOG_MIGRATE_FAILURE  = 38,
PROLOG_FAILURE          = 39,
EPILOG_FAILURE          = 40,
EPILOG_STOP_FAILURE     = 41,
EPILOG_UNDEPLOY_FAILURE = 42,
PROLOG_MIGRATE_POWEROFF_FAILURE = 44,
PROLOG_MIGRATE_SUSPEND_FAILURE  = 46,
BOOT_UNDEPLOY_FAILURE   = 47,
BOOT_STOPPED_FAILURE    = 48,
PROLOG_RESUME_FAILURE   = 49,
PROLOG_UNDEPLOY_FAILURE = 50,
```