### PR TITLE
Rename "My Machines" toolbar item

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -33,7 +33,7 @@
                     <li{{ ' class="active"' if title == 'Machine FAQ' }}><a href="/faq">FAQs</a></li>
                 </ul>
                 <ul class="nav navbar-nav navbar-right">
-                    <li class="logouttoolbar {{ 'active' if title == 'Machines' }}"><a href="/machines">My Machines</a></li>
+                    <li class="logouttoolbar {{ 'active' if title == 'Machines' }}"><a href="/machines">My Projects & Machines</a></li>
 
                     {% if cloudPlatform == 'opennebula' %}
                     <li class="logouttoolbar {{ 'active' if title == 'Machine History' }}"><a href="/machines/history">History</a></li>


### PR DESCRIPTION
Rename the "My Machines" toolbar item to "My Projects & Machines" so that it's clearer that it's not just ones own machines that are shown.